### PR TITLE
Python 3.4 compatibility, pyramid_layout optional and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Install using [pip][]:
 
     pip install pyramid_raven
 
-Provide a [SENTRY_DSN environment variable][]:
+Configure Raven DSN address in the INI configuration of your application:
+
+    raven.dsn = https://xxx:yyy@sentry.example.com/1
+
+... or provide a [SENTRY_DSN environment variable][]:
 
     SENTRY_DSN=http://public:secret@example.com/1
 
@@ -56,7 +60,13 @@ You can use it to record server side errors:
         
         # XXX E.g.: render error page.
         # ...
-    
+
+### Client side JavaScript errors
+
+Client side error tracking requires that you have
+[pyramid_layout](http://pyramid-layout.readthedocs.org/)
+configured before `pyramid_raven`.
+
 And client side errors:
 
     <!-- in production, in the head of your main layout, above all other js -->

--- a/src/pyramid_raven/__init__.py
+++ b/src/pyramid_raven/__init__.py
@@ -57,7 +57,9 @@ def includeme(config, get_raven=None, panel=None):
     config.add_request_method(get_raven, 'raven', reify=True)
     
     # Configure the ``raven-js`` panel.
-    default_tmpl = 'pyramid_raven:templates/panel.mako'
-    panel_tmpl = settings.get('pyramid_raven.panel_tmpl', default_tmpl)
-    config.add_panel(panel, 'raven-js', renderer=panel_tmpl)
+    if hasattr(config, "add_panel"):
+        # Soft detect if we have pyramid_layout installed
+        default_tmpl = 'pyramid_raven:templates/panel.mako'
+        panel_tmpl = settings.get('pyramid_raven.panel_tmpl', default_tmpl)
+        config.add_panel(panel, 'raven-js', renderer=panel_tmpl)
 

--- a/src/pyramid_raven/client.py
+++ b/src/pyramid_raven/client.py
@@ -31,9 +31,11 @@ def as_context_data(request, method_names=None, property_names=None, safe=None):
           >>> r.charset = 'UTF-8'
           >>> r.cookies = {'a': 'b'}
           >>> r.registry=mock_registry
-          >>> as_context_data(r)
-          {'attributes': {'matchdict': None, 'matched_route': None}, 'cookies': {u'a': u'b'}, 'params (POST)': {}, 'query (GET)': {}, 'headers': {'Host': 'localhost:80'}}
-      
+          >>> as_context_data(r)['attributes']['method']
+          'GET'
+          >>> str(as_context_data(r)['cookies']['a'])
+          'b'
+
       Adds attributes specified in the settings::
       
           >>> mock_registry.settings = {

--- a/src/pyramid_raven/panel.py
+++ b/src/pyramid_raven/panel.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 
 import os
 import re
-import urlparse
 
+from pyramid.compat import urlparse
 from pyramid.path import DottedNameResolver
 
 from .constants import DEFAULT_RAVEN_JS_SRC
@@ -89,7 +89,7 @@ def raven_js_panel(context, request, env=None, to_host_path=None, to_public=None
           >>> vars = raven_js_panel(None, mock_request, env=mock_env)
           >>> vars['dsn']
           'https://user@app.getsentry.com/1'
-          >>> vars['hosts']
+          >>> list(vars['hosts'])
           ['getsentry\\.com\\/']
           >>> assert vars['src'] == DEFAULT_RAVEN_JS_SRC
       
@@ -101,7 +101,7 @@ def raven_js_panel(context, request, env=None, to_host_path=None, to_public=None
           ...       'pyramid_raven.include_hosts': 'baz.com bar.net'
           ... }
           >>> vars = raven_js_panel(None, mock_request, env=mock_env)
-          >>> vars['hosts']
+          >>> list(vars['hosts'])
           ['getsentry\\.com\\/', 'foo\\.com', 'baz\\.com', 'bar\\.net']
       
       As per urls returned by a factory specified as a dotted path::
@@ -113,7 +113,7 @@ def raven_js_panel(context, request, env=None, to_host_path=None, to_public=None
           ...       'pyramid_raven.panel.doctest_include_hosts_factory'
           ... }
           >>> vars = raven_js_panel(None, mock_request, env=mock_env)
-          >>> vars['hosts']
+          >>> list(vars['hosts'])
           ['getsentry\\.com\\/', 'blob\\.io']
           >>> del panel.doctest_include_hosts_factory
       


### PR DESCRIPTION
See commit logs for detailed changes. Unit test coverage 100% on Python 3.

Updated README how to configure Raven using INI.

Make pyramid_layout optional, as it is not strictly needed if you only desire to log Python exceptions.
