### PR TITLE
Python >= 3.3 compatibility and improved `sentry_dsn` detection

### DIFF
--- a/src/pyramid_raven/panel.py
+++ b/src/pyramid_raven/panel.py
@@ -129,7 +129,11 @@ def raven_js_panel(context, request, env=None, to_host_path=None, to_public=None
     
     # Unpack.
     settings = request.registry.settings
-    sentry_dsn = env['SENTRY_DSN']
+    sentry_dsn = settings.get('raven.dsn') or env.get('SENTRY_DSN')
+    if not sentry_dsn:
+        raise EnvironmentError(
+            'Raven DSN not found. It should be set in env or .ini file.')
+
     strip = lambda s: s.strip()
     
     # Get the raven javascript ``src`` url.

--- a/src/pyramid_raven/panel.py
+++ b/src/pyramid_raven/panel.py
@@ -150,7 +150,7 @@ def raven_js_panel(context, request, env=None, to_host_path=None, to_public=None
     if include_hosts_factory: # if a dotted path to a factory function...
         factory = DottedNameResolver().resolve(include_hosts_factory)
         urls += factory(request)
-    hosts = map(to_host_path, urls)
+    hosts = list(map(to_host_path, urls))
     
     # Pass the values through to the panel template.
     return {


### PR DESCRIPTION
In Python 3.3, map returns an iterator. If your function expects a list, it has to be explicitly converted.

For the `sentry_dsn` detection I have opened a ticket: #5. This is a solution.
