### PR TITLE
Declare pyramid_mako as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     install_requires=[
         'pyramid',
         'pyramid_layout',
+        'pyramid_mako',
         'raven',
     ],
     setup_requires=[


### PR DESCRIPTION
pyramid_raven depends on pyramid_mako so it should declare it in setup.py